### PR TITLE
Added more relevant boilerplate

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -1,16 +1,22 @@
+import os
 from argparse import ArgumentParser
-
-from flask import Flask
-
+from flask import Flask, send_from_directory
+from flask_socketio import SocketIO
 from api.routes import test
 
-
 def create_app():
-    app = Flask(__name__)
+    app = Flask(__name__, static_folder="../frontend/dist", template_folder="../frontend/dist")
 
     app.config.from_pyfile('config.py')
     app.register_blueprint(test)
 
+    @app.route("/", defaults={'path': ''})
+    @app.route('/<path:path>')
+    def serve(path):
+        if path != "" and os.path.exists("../frontend/dist/" + path):
+            return send_from_directory("../frontend/dist", path)
+        else:
+            return send_from_directory("../frontend/dist", 'index.html')
     return app
 
 if __name__ == '__main__':
@@ -18,6 +24,19 @@ if __name__ == '__main__':
     parser.add_argument('-p', '--port', default = 5000, type = int, help = 'port to listen on')
     args = parser.parse_args()
     port = args.port
-
+    
     app = create_app()
-    app.run(host = '0.0.0.0', port = port, debug = True, use_reloader =True)
+    socketio = SocketIO(app)
+
+    @socketio.on('connect')
+    def handle_connect():
+        print("Client connected")
+
+    @socketio.on('yjs-update')
+    def handle_update(update):
+        # Broadcast the update to all clients (except the sender)
+        socketio.emit('yjs-update', update, include_self=False)
+        print(update)
+
+
+    socketio.run(app, host='0.0.0.0', port=port, debug=True)

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -9,7 +9,9 @@
       "version": "0.0.0",
       "dependencies": {
         "react": "^18.2.0",
-        "react-dom": "^18.2.0"
+        "react-dom": "^18.2.0",
+        "socket.io-client": "^4.7.2",
+        "yjs": "^13.6.7"
       },
       "devDependencies": {
         "@types/react": "^18.2.15",
@@ -508,6 +510,11 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/@socket.io/component-emitter": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@socket.io/component-emitter/-/component-emitter-3.1.0.tgz",
+      "integrity": "sha512-+9jVqKhRSpsc591z5vX+X5Yyw+he/HCB4iQ/RYxw35CEPaY1gnsNE43nf9n9AaYjAQrTiI/mOwKUKdUs9vf7Xg=="
     },
     "node_modules/@swc/core": {
       "version": "1.3.74",
@@ -1126,7 +1133,6 @@
       "version": "4.3.4",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
       "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-      "dev": true,
       "dependencies": {
         "ms": "2.1.2"
       },
@@ -1167,6 +1173,26 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/engine.io-client": {
+      "version": "6.5.2",
+      "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-6.5.2.tgz",
+      "integrity": "sha512-CQZqbrpEYnrpGqC07a9dJDz4gePZUgTPMU3NKJPSeQOyw27Tst4Pl3FemKoFGAlHzgZmKjoRmiJvbWfhCXUlIg==",
+      "dependencies": {
+        "@socket.io/component-emitter": "~3.1.0",
+        "debug": "~4.3.1",
+        "engine.io-parser": "~5.2.1",
+        "ws": "~8.11.0",
+        "xmlhttprequest-ssl": "~2.0.0"
+      }
+    },
+    "node_modules/engine.io-parser": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-5.2.1.tgz",
+      "integrity": "sha512-9JktcM3u18nU9N2Lz3bWeBgxVgOKpw7yhRaoxQA3FUDZzzw+9WlA6p4G4u0RixNkg14fH7EfEc/RhpurtiROTQ==",
+      "engines": {
+        "node": ">=10.0.0"
       }
     },
     "node_modules/esbuild": {
@@ -1691,6 +1717,15 @@
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "dev": true
     },
+    "node_modules/isomorphic.js": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/isomorphic.js/-/isomorphic.js-0.2.5.tgz",
+      "integrity": "sha512-PIeMbHqMt4DnUP3MA/Flc0HElYjMXArsw1qwJZcm9sqR8mq3l8NYizFMty0pWwE/tzIGH3EKK5+jes5mAr85yw==",
+      "funding": {
+        "type": "GitHub Sponsors ❤",
+        "url": "https://github.com/sponsors/dmonad"
+      }
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -1731,6 +1766,25 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/lib0": {
+      "version": "0.2.78",
+      "resolved": "https://registry.npmjs.org/lib0/-/lib0-0.2.78.tgz",
+      "integrity": "sha512-SV2nU43/6eaYnGH3l0lg2wg1ziB/TH3sAd2E8quXPGwrqo+aX98SNT2ZKucpUr5B8A52jD7ZMjAl+r87Fa/bLQ==",
+      "dependencies": {
+        "isomorphic.js": "^0.2.4"
+      },
+      "bin": {
+        "0gentesthtml": "bin/gentesthtml.js",
+        "0serve": "bin/0serve.js"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "type": "GitHub Sponsors ❤",
+        "url": "https://github.com/sponsors/dmonad"
       }
     },
     "node_modules/locate-path": {
@@ -1814,8 +1868,7 @@
     "node_modules/ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-      "dev": true
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "node_modules/nanoid": {
       "version": "3.3.6",
@@ -2184,6 +2237,32 @@
         "node": ">=8"
       }
     },
+    "node_modules/socket.io-client": {
+      "version": "4.7.2",
+      "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-4.7.2.tgz",
+      "integrity": "sha512-vtA0uD4ibrYD793SOIAwlo8cj6haOeMHrGvwPxJsxH7CeIksqJ+3Zc06RvWTIFgiSqx4A3sOnTXpfAEE2Zyz6w==",
+      "dependencies": {
+        "@socket.io/component-emitter": "~3.1.0",
+        "debug": "~4.3.2",
+        "engine.io-client": "~6.5.2",
+        "socket.io-parser": "~4.2.4"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/socket.io-parser": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.2.4.tgz",
+      "integrity": "sha512-/GbIKmo8ioc+NIWIhwdecY0ge+qVBSMdgxGygevmdHj24bsfgtCmcUUcQ5ZzcylGFHsN3k4HB4Cgkl96KVnuew==",
+      "dependencies": {
+        "@socket.io/component-emitter": "~3.1.0",
+        "debug": "~4.3.1"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
     "node_modules/source-map-js": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
@@ -2381,11 +2460,55 @@
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "dev": true
     },
+    "node_modules/ws": {
+      "version": "8.11.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.11.0.tgz",
+      "integrity": "sha512-HPG3wQd9sNQoT9xHyNCXoDUa+Xw/VevmY9FoHyQ+g+rrMn4j6FB4np7Z0OhdTgjx6MgQLK7jwSy1YecU1+4Asg==",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": "^5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/xmlhttprequest-ssl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-2.0.0.tgz",
+      "integrity": "sha512-QKxVRxiRACQcVuQEYFsI1hhkrMlrXHPegbbd1yn9UHOmRxY+si12nQYzri3vbzt8VdTTRviqcKxcyllFas5z2A==",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/yallist": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
       "dev": true
+    },
+    "node_modules/yjs": {
+      "version": "13.6.7",
+      "resolved": "https://registry.npmjs.org/yjs/-/yjs-13.6.7.tgz",
+      "integrity": "sha512-mCZTh4kjvUS2DnaktsYN6wLH3WZCJBLqrTdkWh1bIDpA/sB/GNFaLA/dyVJj2Hc7KwONuuoC/vWe9bwBBosZLQ==",
+      "dependencies": {
+        "lib0": "^0.2.74"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=8.0.0"
+      },
+      "funding": {
+        "type": "GitHub Sponsors ❤",
+        "url": "https://github.com/sponsors/dmonad"
+      }
     },
     "node_modules/yocto-queue": {
       "version": "0.1.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,7 +11,9 @@
   },
   "dependencies": {
     "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "react-dom": "^18.2.0",
+    "socket.io-client": "^4.7.2",
+    "yjs": "^13.6.7"
   },
   "devDependencies": {
     "@types/react": "^18.2.15",

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,35 +1,62 @@
-import { useState } from 'react'
-import reactLogo from './assets/react.svg'
-import viteLogo from '/vite.svg'
-import './App.css'
+import { useEffect, useRef } from 'react';
+import * as Y from 'yjs';
+import { io } from 'socket.io-client';
+import "./App.css"
 
 function App() {
-  const [count, setCount] = useState(0)
+  const ydoc = useRef(new Y.Doc());
+  const inputRef = useRef<HTMLInputElement | null>(null);
+  const socket = io('http://127.0.0.1:5000');
+
+  useEffect(() => {
+    const ytext = ydoc.current.getText('shared');
+
+    // Sync Yjs text with input value
+    ytext.observe(() => {
+      const ytextValue = ytext.toString();
+      if (inputRef.current && inputRef.current.value !== ytextValue) {
+        inputRef.current.value = ytextValue;
+      }
+    });
+
+    // Listen to remote updates from the server
+    socket.on('yjs-update', (update: Uint8Array) => {
+      const byteArray = new Uint8Array(update);
+      Y.applyUpdate(ydoc.current, byteArray);
+    });
+
+    return () => {
+      socket.disconnect();
+    };
+  }, [socket]);
+
+  const handleChange = () => {
+    if (inputRef.current) {
+      const inputValue = inputRef.current.value;
+      const ytext = ydoc.current.getText('shared');
+      const ytextValue = ytext.toString();
+  
+      if (inputValue !== ytextValue) {
+        ytext.delete(0, ytext.length);
+        ytext.insert(0, inputValue);
+  
+        // Send updates to the server
+        socket.emit('yjs-update', Y.encodeStateAsUpdate(ydoc.current));
+      }
+    }
+  };
 
   return (
     <>
-      <div>
-        <a href="https://vitejs.dev" target="_blank">
-          <img src={viteLogo} className="logo" alt="Vite logo" />
-        </a>
-        <a href="https://react.dev" target="_blank">
-          <img src={reactLogo} className="logo react" alt="React logo" />
-        </a>
-      </div>
-      <h1>Vite + React</h1>
-      <div className="card">
-        <button onClick={() => setCount((count) => count + 1)}>
-          count is {count}
-        </button>
-        <p>
-          Edit <code>src/App.tsx</code> and save to test HMR
-        </p>
-      </div>
-      <p className="read-the-docs">
-        Click on the Vite and React logos to learn more
-      </p>
+      <h1>React Flask Yjs Boilerplate</h1>
+      <input
+        ref={inputRef}
+        type="text"
+        onChange={handleChange}
+        style={{ width: '100%' }}
+      />
     </>
-  )
+  );
 }
 
-export default App
+export default App;


### PR DESCRIPTION
You don't need to merge this PR. I just wanted to share some of the boilerplate that I thought would be useful in this project.

I made quite a few changes when messing around with this.

**New Packages**:
- yjs: This is a CRDT library. We will probably need to use CRDTs to store and sync text documents. This allows us to do so with edits from multiple sources concurrently. 
- socket.io-client: Pretty self-explanatory. We need a client to connect to the server web sockets.

**Proposed architecture change**:
I had some discussion with some of the folks in the backend thread about Frontend vs Backend page routing. While I think it makes more sense to do a MPA using backend routing, I realize that might not be very feasible since React is designed to make SPAs. That being said, we still need to serve the initial page with our backend. Hence lines 13-19 in app.py.

**Build steps**:
Now that we are delivering the initial page using Flask, ```npm run dev``` is not needed. you can just build the frontend and run Flask. Socket.IO also messes with the ```flask run``` command. Socket.IO won't work (at least from what I've seen) when ran with ```flask run```. You can use ```python app.py``` instead to run the app.py file manually. I am not sure if there is a better way to do this. Maybe have a bash script that builds the frontend and runs the backend.

Let me know of any criticisms or things I can do better. Like I said this was just me messing around and getting to know the framework better. Currently this is a working real time "editor". You can have two clients and changes from one client affects the other.

