### PR TITLE
config: setup vite and tsconfig import aliases correctly and correct …

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,8 +1,7 @@
 import React from "react";
 import LoadingPage from "./components/loading";
-
-import { ModeToggle } from "./shadcn/components/ui/mode-toggle";
-import { ThemeProvider } from "@shadcn/ui/theme-provider";
+import { ThemeProvider } from "shadcn/ui/theme-provider";
+import { ModeToggle } from "shadcn/ui/mode-toggle";
 
 const LOADING_MESSAGE = [
   "Load environment variables",

--- a/frontend/src/components/loading.tsx
+++ b/frontend/src/components/loading.tsx
@@ -1,17 +1,16 @@
-import Logo from "./ui/logo";
-import ProgressBar from "./ui/progress-bar";
+import Logo from "components/ui/logo";
+import ProgressBar from "components/ui/progress-bar";
 
 type LoadingPageProps = {
   message?: string;
   progress?: number;
-
 };
-function LoadingPage({ message, progress}: LoadingPageProps) {
+function LoadingPage({ message, progress }: LoadingPageProps) {
   return (
     <div className="w-screen max-w-md">
       <Logo className="mx-auto mb-8 rounded-md " />
       <ProgressBar progress={progress} />
-      <p className="text-muted-foreground text-sm text-center">{message}...</p>
+      <p className="text-center text-sm text-muted-foreground">{message}...</p>
     </div>
   );
 }

--- a/frontend/src/components/ui/logo.tsx
+++ b/frontend/src/components/ui/logo.tsx
@@ -1,6 +1,7 @@
 import { cva } from "class-variance-authority";
-import { cn } from "../../lib/utils";
-import { useTheme } from "@shadcn/ui/theme-provider";
+import { cn } from "lib/utils";
+import { useTheme } from "shadcn/ui/theme-provider";
+
 
 type Props = {
   size?: "sm" | "md" | "lg" | "xl";
@@ -22,7 +23,7 @@ const LogoVariants = cva("loading", {
 
 function Logo({ size, className, ...res }: Props) {
   const { theme } = useTheme();
-  
+
   return (
     <img
       src={

--- a/frontend/src/components/ui/progress-bar.tsx
+++ b/frontend/src/components/ui/progress-bar.tsx
@@ -1,5 +1,5 @@
 import { VariantProps, cva } from "class-variance-authority";
-import { cn } from "../../lib/utils";
+import { cn } from "lib/utils";
 
 const ProgressBarVariants = cva("loading", {
   variants: {

--- a/frontend/src/shadcn/components/ui/button.tsx
+++ b/frontend/src/shadcn/components/ui/button.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import { Slot } from "@radix-ui/react-slot";
 import { cva, type VariantProps } from "class-variance-authority";
-import { cn } from "@lib/utils";
+import { cn } from "lib/utils";
 
 const buttonVariants = cva(
   "inline-flex items-center justify-center rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50",

--- a/frontend/src/shadcn/components/ui/dropdown-menu.tsx
+++ b/frontend/src/shadcn/components/ui/dropdown-menu.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import * as DropdownMenuPrimitive from "@radix-ui/react-dropdown-menu";
 import { Check, ChevronRight, Circle } from "lucide-react";
-import { cn } from "@lib/utils";
+import { cn } from "lib/utils";
 
 const DropdownMenu = DropdownMenuPrimitive.Root;
 

--- a/frontend/src/shadcn/components/ui/input.tsx
+++ b/frontend/src/shadcn/components/ui/input.tsx
@@ -1,4 +1,4 @@
-import { cn } from "@lib/utils";
+import { cn } from "lib/utils";
 import * as React from "react";
 
 export interface InputProps
@@ -10,7 +10,7 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(
       <input
         type={type}
         className={cn(
-          "flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/80  focus-visible:ring-offset-2  disabled:cursor-not-allowed disabled:opacity-50 invalid:focus-visible:ring-ring-error",
+          "flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/80  focus-visible:ring-offset-2  invalid:focus-visible:ring-ring-error disabled:cursor-not-allowed disabled:opacity-50",
           className
         )}
         ref={ref}

--- a/frontend/src/shadcn/components/ui/mode-toggle.tsx
+++ b/frontend/src/shadcn/components/ui/mode-toggle.tsx
@@ -1,14 +1,15 @@
 import { Moon, Sun } from "lucide-react";
 
-import { Button } from "@shadcn/ui/button";
-
 import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from "./dropdown-menu";
-import { useTheme } from "./theme-provider";
+import { useTheme } from "shadcn/ui/theme-provider";
+import { Button } from "shadcn/ui/button"
+
+
 
 export function ModeToggle() {
   const { setTheme } = useTheme();

--- a/frontend/src/tests/components/ui/progress-bar.test.tsx
+++ b/frontend/src/tests/components/ui/progress-bar.test.tsx
@@ -1,5 +1,5 @@
 import { render } from "@testing-library/react";
-import { describe, test } from "vitest";
+import { describe, test, expect } from "vitest";
 
 import ProgressBar from "../../../components/ui/progress-bar";
 

--- a/frontend/src/tests/setup.tsx
+++ b/frontend/src/tests/setup.tsx
@@ -1,4 +1,4 @@
-import matchers from "@testing-library/jest-dom/matchers";
+import matchers from "@testing-library/jest-dom";
 import { cleanup } from "@testing-library/react";
 import { afterEach, expect } from "vitest";
 

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,7 +1,5 @@
 {
   "compilerOptions": {
-
-
     "target": "ES2020",
     "useDefineForClassFields": true,
     "lib": ["ES2020", "DOM", "DOM.Iterable"],
@@ -16,27 +14,23 @@
     "isolatedModules": true,
     "noEmit": true,
     "jsx": "react-jsx",
-    "baseUrl": "./src",
+    "baseUrl": ".",
     "paths": {
-      "@/*": ["./src/*"],
-      "@shadcn/*": ["shadcn/components/*"],
-      "@lib/*": ["lib/*"],
-      "@/components/*": ["./src/components/*"],
-      "@/components/ui/*": ["./src/components/ui/*"],
-      "@/components/layout/*": ["./src/components/layout/*"],
-      "@/lib/*": ["./src/lib/*"],
-      "@/hooks/*": ["./src/hooks/*"],
-      "@/pages/*": ["./src/pages/*"],
-      "@/types/*": ["./types/*"],
-      "@/config/*": ["./src/config/*"],
-      "@/styles/*": ["./src/styles/*"],
-      "@/utils/*": ["./src/utils/*"],
-      "@/assets/*": ["./src/assets/*"],
-      "@/public/*": ["./public/*"],
-      "@/store/*": ["./src/store/*"],
-      "@/services/*": ["./src/services/*"],
+      "@/*": ["./src/*", "./dist/*", ""],
+      "components/*": ["./src/components/*"],
+      "hooks/*": ["./src/hooks/*"],
+      "types/*": ["./src/types/*"],
+      "config/*": ["./src/config/*"],
+      "pages/*": ["./src/pages/*"],
+      "assets/*": ["./src/assets/*"],
+      "public/*": ["./public/*"],
+      "styles/*": ["./src/styles/*"],
+      "store/*": ["./src/store/*"],
+      "services/*": ["./src/services/*"],
+      "shadcn/*": ["./src/shadcn/components/*"],
+      "lib/*": ["./src/lib/*"]
     }
   },
-  "include": ["src", "@/components/ui", "@/components/ui","*.ts", "*.tsx", "src/**/*.ts", "src/**/*.d.ts"],
+  "include": ["src", "*.ts", "*.tsx", "src/**/*.ts", "src/**/*.d.ts"],
   "exclude": ["node_modules", "dist"]
 }

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -3,7 +3,6 @@
 import react from "@vitejs/plugin-react-swc";
 import { defineConfig } from "vite";
 import path from "path";
-
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [react()],
@@ -14,22 +13,19 @@ export default defineConfig({
   },
   resolve: {
     alias: {
-      "@": path.resolve(__dirname, "./src"),
-      "@shadcn": path.resolve(__dirname, "./src/shadcn/components"), // alias for shadcn primitive components
-      "@lib": path.resolve(__dirname, "./src/lib"),
-      "@/components/*": "./src/components/*",
-      "@/components/ui/*": "./src/components/ui/*",
-      "@/components/layout/*": "./src/components/layout/*",
-      "@/hooks/*": "./src/hooks/*",
-      "@/pages/*": "./src/pages/*",
-      "@/types/*": "./types/*",
-      "@/config/*": "./src/config/*",
-      "@/styles/*": "./src/styles/*",
-      "@/utils/*": "./src/utils/*",
-      "@/assets/*": "./src/assets/*",
-      "@/public/*": "./public/*",
-      "@/store/*": "./src/store/*",
-      "@/services/*": "./src/services/*"
+      "@": path.resolve(__dirname, "./src/"),
+      components: `${path.resolve(__dirname, "./src/components/")}`,
+      hooks: `${path.resolve(__dirname, "./src/hooks/")}`,
+      types: `${path.resolve(__dirname, "./src/types/")}`,
+      config: `${path.resolve(__dirname, "./src/config/")}`,
+      pages: `${path.resolve(__dirname, "./src/pages/")}`,
+      assets: `${path.resolve(__dirname, "./src/assets/")}`,
+      public: `${path.resolve(__dirname, "./public/")}`,
+      styles: `${path.resolve(__dirname, "./src/styles/")}`,
+      store: `${path.resolve(__dirname, "./src/store/")}`,
+      services: `${path.resolve(__dirname, "./src/services/")}`,
+      shadcn: `${path.resolve(__dirname, "./src/shadcn/components/")}`,
+      lib: `${path.resolve(__dirname, "./src/lib/")}`,
     },
   },
 });


### PR DESCRIPTION
This PR fixes alias configuration in the vite config and ts configuration files. This alllows us to import easily, consistency across codebase and vscode intellisense. There are two ways you may import files:
1. add a '@/' before the file and the configuration resolves them to ./src/*. For example, 'components' is a folder inside src. To import a file from 'components' folder, you may do this: `import MyComponent from '@/components/ui/MyComponent`
2.  the folder name directly. For example, 'components' is a folder inside src. To import a file from 'components' folder, you may do this: `import MyComponent from 'components/ui/MyComponent'`

I'd advise to use the 2nd way of imports going forward so that if we use any 3rd party packages with imports that have '@' , it reduces confusion.
This PR also takes the fix from pending PR #27 by @believemanasseh which corrects the jest import for the test setup file.

