### PR TITLE
CI: Makefile commands for MongoDB container set up

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,19 +6,34 @@ To set up the development environment, first fork the repo, then clone it to you
 
 CD into the frontend directory and run the following commands:
 
-`npm install`
-`npm run dev`
+```bash
+npm install
+npm run dev
+```
 
 ## Backend
 
 CD into the backend directory, then install pipenv and the project dependencies:
 
-`pip install pipenv`
-`pipenv install`
+```bash
+pip install pipenv
+pipenv install
+```
 
-Enable the virtual environment and run the flask application (defaults to port 5000):
+You will need a MongoDB instance - if you've got Docker installed, the Makefile can spin up a Docker container for you with `make dbup`. You can also run the app in another terminal tab or window and use `make dbseed` to seed the database. If you don't have Makefile installed, you can also of course run the commands manually.
 
-`pipenv run py app.py`
+Once your MongoDB instance is setup, make sure you go to config.py and change your database connection settings according to either your local database settings or the MongoDB container settings:
+```sh
+port: 8081
+database host: localhost
+username: mongo
+password: test
+database: mongo
+```
+To launch the backend, enable the virtual environment and run the flask application (defaults to port 5000):
+
+```bash
+pipenv run py app.py```
 
 # What is CO-DE?
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ pip install pipenv
 pipenv install
 ```
 
-You will need a MongoDB instance - if you've got Docker installed, the Makefile can spin up a Docker container for you with `make dbup`. You can also run the app in another terminal tab or window and use `make dbseed` to seed the database. If you don't have Makefile installed, you can also of course run the commands manually.
+You will need a MongoDB instance - if you've got Docker installed, the Makefile can spin up a Docker container for you with `make dbup`. You can also run the app in another terminal tab or window and use `make dbseed` to seed the database. If you don't have CMake installed, you can also of course run the commands manually.
 
 Once your MongoDB instance is setup, make sure you go to config.py and change your database connection settings according to either your local database settings or the MongoDB container settings:
 ```sh

--- a/backend/Makefile
+++ b/backend/Makefile
@@ -1,0 +1,13 @@
+# Commands retaining to set-up and teardown of a MongoDB Docker container
+up:
+	pipenv run python3 app.py
+dbup:
+	docker run --env mongodb_init_root_username=mongo --env mongodb_init_root_password=test -d -p 8081:27017 --name codemongo mongo:7.0.1
+dbdown:
+	docker rm -f codemongo
+mongosh:
+	docker exec -it codemongo mongosh
+dbre:
+	make dbdown && make dbup
+dbseed:
+	 curl -X POST http://localhost:5000/users -d '{"username":"test", "full_name":"testy testius", "email":"test@example.com", "password":"Password1!"}' -H 'content-type:application/json'


### PR DESCRIPTION
- Creates a Makefile with commands to manage set-up and teardown of a MongoDB docker container.
- Update main README.md to account for database connection information

At some point I would like to introduce a fully-working Docker Compose file, but I've been having some issues trying to get the containers to talk to each other so this will have to do for now.

The reason why this PR has been opened is that as mentioned in #47 if we want to continue this project to completion, we should make it as easy as possible for new contributors to start contributing.